### PR TITLE
Added vim.schedule so visual selections work with other pending text …

### DIFF
--- a/lua/full_visual_line/internal.lua
+++ b/lua/full_visual_line/internal.lua
@@ -12,7 +12,7 @@ end
 function M.setup_autocmd()
 	a.nvim_create_autocmd({ 'CursorMoved', 'ModeChanged' }, {
 		group = autocmd_group,
-		callback = M.handle_autocmd,
+		callback = vim.schedule_wrap(M.handle_autocmd),
 	})
 end
 


### PR DESCRIPTION
Fixes https://github.com/0xAdk/full_visual_line.nvim/issues/2

By deferring the evaluation of `full_visual_line.nvim`, it gives time for other text object operators to execute first

## Bad (current master branch)
https://github.com/0xAdk/full_visual_line.nvim/assets/10103049/3eb1a562-0d26-4190-aa16-0f0400640864

## Fixed (this branch)
https://github.com/0xAdk/full_visual_line.nvim/assets/10103049/be7ebd87-dbce-49ba-8d75-0612646f32a8