### PR TITLE
docs: add AstroNvim configuration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ A simple plugin that highlights whole lines in linewise visual mode (`V`)
 }
 ```
 </details>
+<details open>
+<summary>AstroNvim</summary>
+
+> [astronvim/astronvim](https://github.com/astronvim/astronvim)
+```lua
+return {
+    {
+        "0xAdk/full_visual_line.nvim",
+        event = "VeryLazy",
+        opts = {},
+    },
+}
+```
+</details>
 
 <details>
 <summary>packer.nvim</summary>


### PR DESCRIPTION
Environment:
- `AstroNvim 6.0.6`
- `NVIM v0.12.4`
- `LuaJIT 2.1.1774638290`
- `Windows 11 Pro 25H2 (Build 26200.8875)`

When configured with:
```lua
{
    "0xAdk/full_visual_line.nvim",
    keys = "V",
    opts = {},
}
```
the plugin loads, but the `ModeChanged` event does not fire immediately
when entering Visual Line mode. It fires on the first action after entering V mode.

Using:
```lua
{
    "0xAdk/full_visual_line.nvim",
    event = "VeryLazy",
    opts = {},
}
```

works as expected.

I also tested the same lazy.nvim configuration outside AstroNvim, where
`keys = "V"` behaves correctly, so this appears to be related to AstroNvim's configuration.